### PR TITLE
children in FormModal

### DIFF
--- a/web/src/App/components/FormModal/index.js
+++ b/web/src/App/components/FormModal/index.js
@@ -13,6 +13,7 @@ export default class FormModal extends React.Component {
     title: PropTypes.node,
     confirmText: PropTypes.node,
     mutation: PropTypes.string,
+    children: PropTypes.node,
     doc: PropTypes.object,
     only: PropTypes.any,
     omit: PropTypes.any,
@@ -42,6 +43,7 @@ export default class FormModal extends React.Component {
         only={this.props.only}
         omit={this.props.omit}
         onSuccess={this.props.onSuccess}
+        children={this.props.children}
       />
     )
   }


### PR DESCRIPTION
Probando el FormModal me encontré con que no recibe this.props.children para permitir Fields específicos como en el caso del AutoForm. Siendo que llama a AutoForm probé recibir this.props.children como object y mandárselos al Autoform para que sea el AutoForm el que decida como renderizar cada campo (al especificarse en los propTypes del AutoForm como recibe el children).

Si bien me funcionó probando con distintos campos, me gustaría saber si este cambio es correcto, si bien es bastante sencillo, y cómo se aplicaría de manera correcta.